### PR TITLE
JBDS-4730: Use "Red Hat CodeReady Studio" instead of "Red Hat Develop…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -29,7 +29,7 @@ This repo should be considered a wiki, into which all developers can push docs. 
 ** link:source/build_checks.adoc[Build-time baseline and maven enforcer checks]
 ** link:source/build_source_bundles_features_and_src_zips.adoc[How to build source bundles, features, and source zips]
 ** link:building/build_job_cascade_and_where_to_find_build_results.adoc[How to build the whole JBoss Tools cascade / stack of projects]
-*** link:list_of_projects.adoc[List of projects in JBoss Tools / Red Hat Developer Studio]
+*** link:list_of_projects.adoc[List of projects in JBoss Tools / Red Hat CodeReady Studio]
 ** link:building/export_plugin_from_eclipse.adoc[Exporting plugins from eclipse]
 ** link:building/tycho.adoc[All about Tycho]
 *** link:building/how_to_test_tycho.adoc[How to test new versions of Tycho]
@@ -54,7 +54,7 @@ This repo should be considered a wiki, into which all developers can push docs. 
 ** link:building/target_platforms/target_platforms_updates.adoc[Requesting Target Platform Updates]
 ** link:source/how_to_add_an_update_site.adoc[Adding an update site] or link:source/build_update_sites_using_associate_sites.adoc[associate site]
 ** link:source/composite_site_regeneration.adoc[Regenerating a composite update site]
-** link:source/publishing_features_downstream.adoc[Publishing features to JBoss Tools, Red Hat Developer Studio, JBoss Central, Early Access, and Eclipse Marketplace]
+** link:source/publishing_features_downstream.adoc[Publishing features to JBoss Tools, Red Hat CodeReady Studio, JBoss Central, Early Access, and Eclipse Marketplace]
 ** link:source/third_party.adoc[Bundling Third Party Library Dependencies]
 ** link:source/pde-source-lookup.adoc[Using the PDE Source Lookup plugin]
 ** Versioning Rules

--- a/building/build_job_cascade_and_where_to_find_build_results.adoc
+++ b/building/build_job_cascade_and_where_to_find_build_results.adoc
@@ -1,6 +1,6 @@
 = Build cascade & results
 
-Each year our process for building JBoss Tools & Red Hat Developer Studio evolves and improves,
+Each year our process for building JBoss Tools & Red Hat CodeReady Studio evolves and improves,
 so each year our process documentation is by necessity also evolving (and hopefully improving, too).
 
 The basic workflow can be defined as follows:
@@ -18,7 +18,7 @@ The basic workflow can be defined as follows:
 
 3. Then, for JBoss Tools, we build a series of aggregate update sites (core, coretests, central, earlyaccess).
 
-4. For Red Hat Developer Studio, we then we build the JBoss Developer Studio update site, and use that to build the installers.
+4. For Red Hat CodeReady Studio, we then we build the JBoss Developer Studio update site, and use that to build the installers.
 
 All builds depend on their respective target platforms being built and up-to-date with the latest upstream dependencies from Eclipse and other third-party vendors.
 

--- a/building/setup_development_environment.adoc
+++ b/building/setup_development_environment.adoc
@@ -8,10 +8,10 @@ This article explains the different options you have to set up a first-class dev
 
 JBoss Tools 4.3 requires Java 8. JBoss Tools 4.2 required Java 7 or 8.
 
-For other versions of JBoss Tools or Red Hat Developer Studio, see:
+For other versions of JBoss Tools or Red Hat CodeReady Studio, see:
 
 * https://developer.jboss.org/wiki/MatrixOfSupportedPlatformsRuntimesAndTechnologiesInJBossToolsJBDS[Matrix of supported platforms, runtimes and technologies in JBossTools & JBDS] or
-* https://access.redhat.com/articles/427493[Red Hat Developer Studio Components and Supported Configurations]
+* https://access.redhat.com/articles/427493[Red Hat CodeReady Studio Components and Supported Configurations]
 
 === Eclipse Base Installation
 

--- a/building/target_platforms/target_platforms_for_consumers.adoc
+++ b/building/target_platforms/target_platforms_for_consumers.adoc
@@ -22,7 +22,7 @@ See these slides for more about target platforms: http://www.slideshare.net/mick
 
 JBoss Tools' `target platform definition files` are stored in github:
 
-* https://github.com/jbosstools/jbosstools-target-platforms[JBoss Tools & Red Hat Developer Studio Target Platforms]
+* https://github.com/jbosstools/jbosstools-target-platforms[JBoss Tools & Red Hat CodeReady Studio Target Platforms]
 * https://github.com/jbosstools/jbosstools-discovery[JBoss Tools Central Target Platforms]
 * https://github.com/jbosstools/jbosstools-integration-stack[Integration Stack Target Platforms]
 

--- a/building/target_platforms/target_platforms_updates.adoc
+++ b/building/target_platforms/target_platforms_updates.adoc
@@ -309,7 +309,7 @@ Proposed change to target platform ${TARGET_PLATFORM_VERSION}
 
 Body:
 
-Here is a proposal for a change to the JBoss Tools and Red Hat Developer Studio ${TARGET_PLATFORM_VERSION} target platforms.
+Here is a proposal for a change to the JBoss Tools and Red Hat CodeReady Studio ${TARGET_PLATFORM_VERSION} target platforms.
 
 ${PR_URL}
 

--- a/community/README.adoc
+++ b/community/README.adoc
@@ -18,7 +18,7 @@ For the latest announced milestone release schedule, see https://issues.jboss.or
 
 === Release Guide
 
-The release guide for JBoss Tools and Red Hat Developer Studio is located here: https://github.com/jbdevstudio/jbdevstudio-devdoc[jbdevstudio-devdoc].
+The release guide for JBoss Tools and Red Hat CodeReady Studio is located here: https://github.com/jbdevstudio/jbdevstudio-devdoc[jbdevstudio-devdoc].
 
 If not authorized, or you get a 404, please submit a PR to get your github username added to https://github.com/jbdevstudio/github-teams/blob/master/jbdevstudio-teams/jbdevstudio-devdoc.team[jbdevstudio-devdoc.team].
 

--- a/community/release_guidelines.adoc
+++ b/community/release_guidelines.adoc
@@ -1,5 +1,5 @@
 = Release Guidelines
 
-The release process for JBoss Tools and Red Hat Developer Studio is an evolving process.
+The release process for JBoss Tools and Red Hat CodeReady Studio is an evolving process.
 
 Documentation can be found here: https://github.com/jbdevstudio/jbdevstudio-devdoc/tree/master/release_guide[jbdevstudio-product] footnote:[Don't have permission to view the repo? You can https://github.com/jbdevstudio/github-teams/blob/master/jbdevstudio-teams/README.adoc#guide-for-users[request access here].]:

--- a/list_of_projects.adoc
+++ b/list_of_projects.adoc
@@ -2,7 +2,7 @@
 
 Below is a table listing the projects in http://tools.jboss.org/downloads/overview.html[JBoss Tools], with links to their source repos, builds, update sites, & jobs.
 
-You can also see which projects are mature enough to be included in https://developers.redhat.com/products/devstudio/download/[Red Hat Developer Studio] (Devstudio),
+You can also see which projects are mature enough to be included in https://developers.redhat.com/products/devstudio/download/[Red Hat CodeReady Studio] (Devstudio),
 Red Hat Central, or available from Early Access within Central.
 
 IMPORTANT: _[blue]#Looking for 4.4.x? See https://github.com/jbosstools/jbosstools-devdoc/blob/jbosstools-4.4.x/list_of_projects.adoc[4.4.x Branch Project List]#_
@@ -266,7 +266,7 @@ image:images/terminal.png[title="log", alt="log", link="https://dev-platform-jen
 |===
 
 
-== Projects in Red Hat Developer Studio
+== Projects in Red Hat CodeReady Studio
 
 .JBoss Developer Studio - 11.x branch
 [cols="2e,^m,^m,^m,^m,^2m",options="header"]

--- a/list_of_projects_4.4.neon.adoc
+++ b/list_of_projects_4.4.neon.adoc
@@ -2,7 +2,7 @@
 
 Below is a table listing the projects in http://tools.jboss.org/downloads/overview.html[JBoss Tools], with links to their source repos, builds, update sites, & jobs.
 
-You can also see which projects are mature enough to be included in http://www.jboss.org/products/devstudio/download/[Red Hat Developer Studio] (JBDS), JBoss Central, or available from Early Access within Central.
+You can also see which projects are mature enough to be included in http://www.jboss.org/products/devstudio/download/[Red Hat CodeReady Studio] (JBDS), JBoss Central, or available from Early Access within Central.
 
 IMPORTANT: _[blue]#Looking for 4.3.x? See https://github.com/jbosstools/jbosstools-devdoc/blob/jbosstools-4.3.x/list_of_projects.adoc[4.3.x Branch Project List]#_
 
@@ -272,7 +272,7 @@ image:images/terminal.png[title="log", alt="log", link="https://dev-platform-jen
 |===
 
 
-== Projects in Red Hat Developer Studio
+== Projects in Red Hat CodeReady Studio
 
 .JBoss Developer Studio - 10.x branch
 [cols="2e,^m,^m,^m,^m,^2m",options="header"]

--- a/source/publishing_features_downstream.adoc
+++ b/source/publishing_features_downstream.adoc
@@ -1,4 +1,4 @@
-= Publishing features to JBoss Tools, Red Hat Developer Studio, JBoss Central, Early Access, and Eclipse Marketplace
+= Publishing features to JBoss Tools, Red Hat CodeReady Studio, JBoss Central, Early Access, and Eclipse Marketplace
 
 Once your features are ready for consumption by other projects, you can have them aggregated into a downstream project.
 
@@ -9,7 +9,7 @@ Submit a pull request against the appropriate branch of the https://github.com/j
 * https://github.com/jbosstools/jbosstools-build-sites/tree/master/aggregate/site/category.xml[aggregate/site/category.xml] - for all features
 * https://github.com/jbosstools/jbosstools-build-sites/tree/master/aggregate/coretests-site/category.xml[aggregate/coretests-site/category.xml] - for test features
 
-== Red Hat Developer Studio
+== Red Hat CodeReady Studio
 
 First, ensure your feature(s) are included in JBoss Tools, as above.
 

--- a/source/versioning-build-artifacts.adoc
+++ b/source/versioning-build-artifacts.adoc
@@ -1,6 +1,6 @@
 = Versioning rules for build artifacts
 
-This document describes how we handle the versioning of build artifacts in JBoss Tools and Red Hat Developer Studio.
+This document describes how we handle the versioning of build artifacts in JBoss Tools and Red Hat CodeReady Studio.
 
 :toc: macro
 toc::[]
@@ -31,7 +31,7 @@ Parent pom also controls a few other important properties, such as the version o
 As noted below, the version of the parent pom is used to define the "version" of JBoss Tools for the purpose of controlling downstream version-specific changes, such as which JBoss Central site from which to fetch updates.
 
 
-== Properties that define what version of JBoss Tools and Red Hat Developer Studio is running
+== Properties that define what version of JBoss Tools and Red Hat CodeReady Studio is running
 
 There are two plugins which control which version of the "product" is running. These are:
 

--- a/source/versioning.adoc
+++ b/source/versioning.adoc
@@ -1,6 +1,6 @@
 = Versioning rules
 
-This document describes how we handle the versioning of plugins, features, products, installers, and update sites in JBoss Tools and Red Hat Developer Studio.
+This document describes how we handle the versioning of plugins, features, products, installers, and update sites in JBoss Tools and Red Hat CodeReady Studio.
 
 :toc: macro
 toc::[]


### PR DESCRIPTION
…er Studio" in graphics & text

Signed-off-by: Jeff MAURY <jmaury@redhat.com>